### PR TITLE
fix: precondition of caller balance

### DIFF
--- a/halmos.toml
+++ b/halmos.toml
@@ -12,7 +12,7 @@
 loop = 16
 
 # use the given command when invoking the solver
-solver-command = "yices-smt2"
+solver-command = "yices-smt2 --smt2-model-format"
 
 # cache unsat queries using unsat cores
 cache-solver = false

--- a/test/EIP2935.t.sol
+++ b/test/EIP2935.t.sol
@@ -92,6 +92,7 @@ contract EIP2935Test is SymTest, Test {
     function check_operation(address caller, uint value, bytes memory data) public {
         // set symbolic balance for caller
         uint256 callerBalance = svm.createUint(96, "caller.balance");
+        vm.assume(callerBalance >= value);
         vm.deal(caller, callerBalance);
 
         // call HISTORY_STORAGE_ADDRESS

--- a/test/EIP7002.t.sol
+++ b/test/EIP7002.t.sol
@@ -99,6 +99,7 @@ contract EIP7002Test is SymTest, Test {
 
         // set symbolic balance for caller
         uint256 callerBalance = svm.createUint(96, "caller.balance");
+        vm.assume(callerBalance >= value);
         vm.deal(caller, callerBalance);
 
         // call the contract and capture the new contract state
@@ -178,6 +179,7 @@ contract EIP7002Test is SymTest, Test {
 
         // set symbolic balance for caller
         uint256 callerBalance = svm.createUint(96, "caller.balance");
+        vm.assume(callerBalance >= value);
         vm.deal(caller, callerBalance);
 
         // call the contract and capture the new contract state

--- a/test/EIP7251.t.sol
+++ b/test/EIP7251.t.sol
@@ -99,6 +99,7 @@ contract EIP7251Test is SymTest, Test {
 
         // set symbolic balance for caller
         uint256 callerBalance = svm.createUint(96, "caller.balance");
+        vm.assume(callerBalance >= value);
         vm.deal(caller, callerBalance);
 
         // call the contract and capture the new contract state
@@ -177,6 +178,7 @@ contract EIP7251Test is SymTest, Test {
 
         // set symbolic balance for caller
         uint256 callerBalance = svm.createUint(96, "caller.balance");
+        vm.assume(callerBalance >= value);
         vm.deal(caller, callerBalance);
 
         // call the contract and capture the new contract state


### PR DESCRIPTION
updated the precondition to ensure that the caller's balance covers the call value.

context: halmos previously implicitly ignored insufficient call value errors, but this is no longer the case in the latest version. so a stronger precondition is now required. note that this change is orthogonal to the verification spec, and more related to solidity-specific behavior.